### PR TITLE
Update functions.php

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * Функция ord() для мультибайтовы строк
+ * Функция ord() для мультибайтовых строк
  *
  * @param string $c символ utf-8
  * @return int код символа
  */
 function uniord($c)
 {
-    $h = ord($c{0});
+    $h = ord($c[0]);
     if ($h <= 0x7F) {
         return $h;
     } else {
@@ -15,16 +15,16 @@ function uniord($c)
             return false;
         } else {
             if ($h <= 0xDF) {
-                return ($h & 0x1F) << 6 | (ord($c{1}) & 0x3F);
+                return ($h & 0x1F) << 6 | (ord($c[1]) & 0x3F);
             } else {
                 if ($h <= 0xEF) {
-                    return ($h & 0x0F) << 12 | (ord($c{1}) & 0x3F) << 6
-                        | (ord($c{2}) & 0x3F);
+                    return ($h & 0x0F) << 12 | (ord($c[1]) & 0x3F) << 6
+                        | (ord($c[2]) & 0x3F);
                 } else {
                     if ($h <= 0xF4) {
-                        return ($h & 0x0F) << 18 | (ord($c{1}) & 0x3F) << 12
-                            | (ord($c{2}) & 0x3F) << 6
-                            | (ord($c{3}) & 0x3F);
+                        return ($h & 0x0F) << 18 | (ord($c[1]) & 0x3F) << 12
+                            | (ord($c[2]) & 0x3F) << 6
+                            | (ord($c[3]) & 0x3F);
                     } else {
                         return false;
                     }


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets deprecated: 

https://wiki.php.net/rfc/deprecate_curly_braces_array_access , so, `$c{N}` replaced to `$c[N]`